### PR TITLE
Hide QR editore while pending re-confirmation

### DIFF
--- a/styles/prosilver/template/event/overall_header_head_append.html
+++ b/styles/prosilver/template/event/overall_header_head_append.html
@@ -1,0 +1,5 @@
+<!-- IF S_NEED_ACCPEPT_PRIVACY -->
+
+{% INCLUDECSS '@tas2580_privacyprotection/privacyprotection.css' %}
+
+<!-- ENDIF -->

--- a/styles/prosilver/template/event/quickreply_editor_panel_before.html
+++ b/styles/prosilver/template/event/quickreply_editor_panel_before.html
@@ -1,0 +1,8 @@
+<!-- IF S_NEED_ACCPEPT_PRIVACY -->
+
+<div class="rules">
+	<p>{NEED_ACCPEPT_PRIVACY}</p>
+	<a href="{U_ACCPEPT_PRIVACY}" class="button2">{L_ACCEPT_PRIVACY}</a>
+</div>
+
+<!-- ENDIF -->

--- a/styles/prosilver/theme/privacyprotection.css
+++ b/styles/prosilver/theme/privacyprotection.css
@@ -1,0 +1,3 @@
+form#qr_postform .panel {
+  display: none;
+}


### PR DESCRIPTION
Hiding QR-editor in fora such configured as long as the new Privacy Policy statement is pending re-confirmation and replacing it with the corresponding info message.