### PR TITLE
Update ucp.php - Issue #75

### DIFF
--- a/language/de/ucp.php
+++ b/language/de/ucp.php
@@ -39,6 +39,6 @@ $lang = array_merge($lang, array(
 	'PRIVACY_ACCEPTED_EXPLAIN'		=> 'Ich bestätige mit dem Auswählen dieses Feldes, das ich die <a href="%s">Datenschutzerklärung</a> gelesen habe und akzeptiere diese.',
 	'PRIVACY_LAST_ACCEPTED'			=> 'Datenschutzerklärung zuletzt akzeptiert',
 	'REVOKE_PRIVACY'				=> 'Widerrufen',
-	'REVOKE_PRIVACY_CONFIRM'		=> 'Bist du dir sicher, dass du deine Zustimmung zur Datenschutzerklärung wiederufen möchtest?',
-	'REVOKE_PRIVACY_SUCCESS'		=> 'Du hast deine Zustimmung zur Datenschutzerklärung erfolgreich wiederufen.',
+	'REVOKE_PRIVACY_CONFIRM'		=> 'Bist du dir sicher, dass du deine Zustimmung zur Datenschutzerklärung widerrufen möchtest?',
+	'REVOKE_PRIVACY_SUCCESS'		=> 'Du hast deine Zustimmung zur Datenschutzerklärung erfolgreich widerrufen.',
 ));

--- a/language/de_x_sie/ucp.php
+++ b/language/de_x_sie/ucp.php
@@ -39,6 +39,6 @@ $lang = array_merge($lang, array(
 	'PRIVACY_ACCEPTED_EXPLAIN'		=> 'Ich bestätige mit dem Auswählen dieses Feldes, das ich die <a href="%s">Datenschutzerklärung</a> gelesen habe und akzeptiere diese.',
 	'PRIVACY_LAST_ACCEPTED'			=> 'Datenschutzerklärung zuletzt akzeptiert',
 	'REVOKE_PRIVACY'				=> 'Widerrufen',
-	'REVOKE_PRIVACY_CONFIRM'		=> 'Sind Sie sich sicher, dass Sie Ihre Zustimmung zur Datenschutzerklärung wiederufen möchten?',
-	'REVOKE_PRIVACY_SUCCESS'		=> 'Sie haben Ihre Zustimmung zur Datenschutzerklärung erfolgreich wiederufen.',
+	'REVOKE_PRIVACY_CONFIRM'		=> 'Sind Sie sich sicher, dass Sie Ihre Zustimmung zur Datenschutzerklärung widerrufen möchten?',
+	'REVOKE_PRIVACY_SUCCESS'		=> 'Sie haben Ihre Zustimmung zur Datenschutzerklärung erfolgreich widerrufen.',
 ));


### PR DESCRIPTION
Typos in _**ucp.php**_  in both _de_ and _de_x_sie_ language packs corrected (Ref.: Issue #75 )